### PR TITLE
Release/1.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sdlb-schema-viewer",
   "description": "React component for visualizing the Smart Data Lake Builder config schema.",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "main": "./dist/main.js",
   "peerDependencies": {
     "@emotion/react": "11.x",

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -49,6 +49,24 @@ Object.defineProperty(global.SVGElement.prototype, 'viewBox', {
   }
 });
 
+Object.defineProperty(global.SVGElement.prototype, 'width', {
+  writable: true,
+  value: {
+    baseVal: {
+      value: 0
+    }
+  }
+});
+
+Object.defineProperty(global.SVGElement.prototype, 'height', {
+  writable: true,
+  value: {
+    baseVal: {
+      value: 0
+    }
+  }
+});
+
 Object.defineProperty(global.URL, 'createObjectURL', {
   writable: true,
   value: jest.fn()

--- a/src/utils/JsonSchemaParser.test.ts
+++ b/src/utils/JsonSchemaParser.test.ts
@@ -382,6 +382,35 @@ describe('schema references are resolved in', () => {
   });
 });
 
+test('fields outside of ref override ref fields', () => {
+  let jsonSchema = {
+    "type": "object",
+    "properties": {
+      "property": {
+        "$ref": "#/definitions/BaseClass/ConcreteClass",
+        "deprecated": true
+      },
+    },
+    "definitions": {
+      "BaseClass": {
+        "ConcreteClass": {
+          "type": "object",
+          "title": "ClassName",
+          "description": "some description",
+          "deprecated": false
+        }
+      }
+    }
+  }
+  const root = new JsonSchemaParser(jsonSchema as JSONSchema).parseSchema();
+
+  const propertyNode = root.children[0] as PropertyNode;
+  expect(propertyNode.type).toBe('object');
+  expect(propertyNode.typeDetails).toBe('ClassName');
+  expect(propertyNode.description).toBe('some description');
+  expect(propertyNode.deprecated).toBe(true);
+});
+
 test('base class is undefined if schema is defined in "Others" section', () => {
   let jsonSchema = {
     "type": "object",

--- a/src/utils/JsonSchemaParser.ts
+++ b/src/utils/JsonSchemaParser.ts
@@ -1,7 +1,11 @@
 import { RootNode, ClassNode, PropertyNode, SchemaType, SchemaNode } from './SchemaNode';
 import { JSONSchema7 } from 'json-schema';
 
-export type JSONSchema = JSONSchema7;
+export type JSONSchema = JSONSchema7 & CanBeDeprecated;
+// deprecated is not yet available in JSON schema draft07
+type CanBeDeprecated = {
+  deprecated?: boolean
+}
 
 // types which are used when a class can be chosen from a list of classes
 const classSelectionTypes: SchemaType[] = ['anyOf', 'allOf', 'oneOf', 'mapOf'];
@@ -105,8 +109,7 @@ export default class JsonSchemaParser {
   }
 
   private isDeprecated(schemaElement: JSONSchema): boolean {
-    // deprecated is a custom field
-    return Boolean((schemaElement as any).deprecated);
+    return Boolean(schemaElement.deprecated);
   }
 
   private parseChildren(type: SchemaType, propertySchema: JSONSchema): SchemaNode[] {


### PR DESCRIPTION
Improvements:
* When parsing the JSON schema, fields on the same level as `$ref` are no longer ignored. In particular, if the referenced schema contains a field with the same name, the value on the same level as `$ref` overrides the value inside the referenced schema.